### PR TITLE
Wagtail 1.0 update & latlng feature

### DIFF
--- a/wagtailgmaps/static/wagtailgmaps/js/map-field.js
+++ b/wagtailgmaps/static/wagtailgmaps/js/map-field.js
@@ -12,7 +12,7 @@ $(document).ready(function() {
       }, function(responses) {
         if (responses && responses.length > 0) {
             $input = $(input);
-            if ($input.hasClass('gmap--latlng')) {
+            if ($input.closest('gmap').hasClass('gmap--latlng')) {
               $input.val(
                 String(responses[0].geometry.location.lat) + ', ' + String(responses[0].geometry.location.lng)
               );
@@ -31,7 +31,7 @@ $(document).ready(function() {
         if (status == google.maps.GeocoderStatus.OK) {
           marker.setPosition(results[0].geometry.location);
           $input = $(input);
-          if ($input.hasClass('gmap--latlng')) {
+          if ($input.closest('gmap').hasClass('gmap--latlng')) {
             $input.val(
               String(results[0].geometry.location.lat) + ', ' + String(results[0].geometry.location.lng)
             );

--- a/wagtailgmaps/static/wagtailgmaps/js/map-field.js
+++ b/wagtailgmaps/static/wagtailgmaps/js/map-field.js
@@ -14,10 +14,10 @@ $(document).ready(function() {
             $input = $(input);
             if ($input.hasClass('gmap--latlng')) {
               $input.val(
-                String(results[0].geometry.location.lat) + ', ' + String(results[0].geometry.location.lng)
+                String(responses[0].geometry.location.lat) + ', ' + String(responses[0].geometry.location.lng)
               );
             } else {
-              $input.val(results[0].formatted_address);
+              $input.val(responses[0].formatted_address);
             }
         } else {
           alert('Cannot determine address at this location.');

--- a/wagtailgmaps/static/wagtailgmaps/js/map-field.js
+++ b/wagtailgmaps/static/wagtailgmaps/js/map-field.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
-  
+
   google.maps.event.addDomListener(window, 'load', function() {
-  
+
     // One geocoder var to rule them all
     var geocoder = new google.maps.Geocoder();
 
@@ -11,7 +11,14 @@ $(document).ready(function() {
         latLng: pos
       }, function(responses) {
         if (responses && responses.length > 0) {
-            $(input).val(responses[0].formatted_address);
+            $input = $(input);
+            if ($input.hasClass('gmap--latlng')) {
+              $input.val(
+                String(results[0].geometry.location.lat) + ', ' + String(results[0].geometry.location.lng)
+              );
+            } else {
+              $input.val(results[0].formatted_address);
+            }
         } else {
           alert('Cannot determine address at this location.');
         }
@@ -23,7 +30,14 @@ $(document).ready(function() {
       geocoder.geocode({'address': address}, function(results, status) {
         if (status == google.maps.GeocoderStatus.OK) {
           marker.setPosition(results[0].geometry.location);
-          $(input).val(results[0].formatted_address);
+          $input = $(input);
+          if ($input.hasClass('gmap--latlng')) {
+            $input.val(
+              String(results[0].geometry.location.lat) + ', ' + String(results[0].geometry.location.lng)
+            );
+          } else {
+            $input.val(results[0].formatted_address);
+          }
           map.setCenter(results[0].geometry.location);
         } else {
           alert("Geocode was not successful for the following reason: " + status);
@@ -56,7 +70,7 @@ $(document).ready(function() {
             marker[map_key].setPosition(event.latLng);
             geocodePosition(marker[map_key].getPosition(), mapElem.input);
           });
-          
+
           // Event listeners to update map when press enter or tab
           $(mapElem.input).bind("enterKey",function(event) {
             geocodeAddress($(this).val(), this, marker[map_key], map[map_key]);
@@ -73,7 +87,7 @@ $(document).ready(function() {
 
     // Method to initialize a map and all of its related components (usually address input and marker)
     window.initialize_map = function (params) {
-        
+
         // Get latlong form address to initialize map
         geocoder.geocode( { "address": params.address}, function(results, status) {
           if (status == google.maps.GeocoderStatus.OK) {
@@ -106,4 +120,4 @@ $(document).ready(function() {
 
   });
 
-}); 
+});

--- a/wagtailgmaps/static/wagtailgmaps/js/map-field.js
+++ b/wagtailgmaps/static/wagtailgmaps/js/map-field.js
@@ -12,9 +12,9 @@ $(document).ready(function() {
       }, function(responses) {
         if (responses && responses.length > 0) {
             $input = $(input);
-            if ($input.closest('gmap').hasClass('gmap--latlng')) {
+            if ($input.closest('.gmap').hasClass('gmap--latlng')) {
               $input.val(
-                String(responses[0].geometry.location.lat) + ', ' + String(responses[0].geometry.location.lng)
+                String(responses[0].geometry.location.lat()) + ', ' + String(responses[0].geometry.location.lng())
               );
             } else {
               $input.val(responses[0].formatted_address);
@@ -31,9 +31,9 @@ $(document).ready(function() {
         if (status == google.maps.GeocoderStatus.OK) {
           marker.setPosition(results[0].geometry.location);
           $input = $(input);
-          if ($input.closest('gmap').hasClass('gmap--latlng')) {
+          if ($input.closest('.gmap').hasClass('gmap--latlng')) {
             $input.val(
-              String(results[0].geometry.location.lat) + ', ' + String(results[0].geometry.location.lng)
+              String(results[0].geometry.location.lat()) + ', ' + String(results[0].geometry.location.lng())
             );
           } else {
             $input.val(results[0].formatted_address);

--- a/wagtailgmaps/templates/wagtailadmin/admin_base.html
+++ b/wagtailgmaps/templates/wagtailadmin/admin_base.html
@@ -1,31 +1,31 @@
 {% extends "wagtailadmin/skeleton.html" %}
-{% load compress wagtailadmin_tags %}
+{% load compress static wagtailadmin_tags %}
 {% load wagtailgmaps_tags %}
 
 {% block css %}
     {% compress css %}
-        <link rel="stylesheet" href="{{ STATIC_URL }}wagtailadmin/{% wagtail_version %}/vendor/jquery-ui/jquery-ui-1.10.3.verdant.css" />
-        <link rel="stylesheet" href="{{ STATIC_URL }}wagtailadmin/{% wagtail_version %}/core.{% wagtail_version %}" type="text/{% wagtail_version %}" />
-        <link rel="stylesheet" href="{{ STATIC_URL }}wagtailgmaps/css/admin.css" type="text/css" />
+        <link rel="stylesheet" href="{% static 'wagtailadmin/css/vendor/jquery-ui/jquery-ui-1.10.3.verdant.css' %}" />
+        <link rel="stylesheet" href="{% static 'wagtailadmin/css/core.css' %}" type="text/css" />
     {% endcompress %}
+        <link rel="stylesheet" href="{%  static 'wagtailgmaps/css/admin.css' %}" type="text/css" />
 
     {% block extra_css %}{% endblock %}
 {% endblock %}
 
 {% block js %}
-     <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
+    <script src="https://maps.google.com/maps/api/js?sensor=false"></script>
     {% compress js %}
-        <script src="{{ STATIC_URL }}wagtailadmin/js/vendor/jquery-1.10.3.js"></script>
-        <script src="{{ STATIC_URL }}wagtailadmin/js/vendor/jquery-ui-1.10.3.js"></script>
-        <script src="{{ STATIC_URL }}wagtailadmin/js/vendor/jquery.datetimepicker.js"></script>
-        <script src="{{ STATIC_URL }}wagtailadmin/js/vendor/jquery.autosize.js"></script>
-        <script src="{{ STATIC_URL }}wagtailadmin/js/vendor/bootstrap-transition.js"></script>
-        <script src="{{ STATIC_URL }}wagtailadmin/js/vendor/bootstrap-modal.js"></script>
-        <script src="{{ STATIC_URL }}wagtailadmin/js/vendor/bootstrap-tab.js"></script>
-        <script src="{{ STATIC_URL }}wagtailadmin/js/vendor/jquery.dlmenu.js"></script>
-        <script src="{{ STATIC_URL }}wagtailadmin/js/core.js"></script>
+        <script src="{% static 'wagtailadmin/js/vendor/jquery-1.10.3.js' %}"></script>
+        <script src="{% static 'wagtailadmin/js/vendor/jquery-ui-1.10.3.js' %}"></script>
+        <script src="{% static 'wagtailadmin/js/vendor/jquery.datetimepicker.js' %}"></script>
+        <script src="{% static 'wagtailadmin/js/vendor/jquery.autosize.js' %}"></script>
+        <script src="{% static 'wagtailadmin/js/vendor/bootstrap-transition.js' %}"></script>
+        <script src="{% static 'wagtailadmin/js/vendor/bootstrap-modal.js' %}"></script>
+        <script src="{% static 'wagtailadmin/js/vendor/bootstrap-tab.js' %}"></script>
+        <script src="{% static 'wagtailadmin/js/vendor/jquery.dlmenu.js' %}"></script>
+        <script src="{% static 'wagtailadmin/js/core.js' %}"></script>
         {% main_nav_js %}
     {% endcompress %}
-    
+
     {% block extra_js %}{% endblock %}
 {% endblock %}

--- a/wagtailgmaps/templates/wagtailadmin/edit_handlers/multi_field_panel.html
+++ b/wagtailgmaps/templates/wagtailadmin/edit_handlers/multi_field_panel.html
@@ -11,12 +11,12 @@
         {% for child in self.children %}
             <li class="{{ child.classes|join:" " }}">
                 {{ child.render_as_field }}
-                {% for class in child.classes %}
-                   {% ifequal class 'gmap' %}
-                        {% load wagtailgmaps_tags %}
-                        {% map_editor child.bound_field.value 100 "%" 300 "px" 8 %}
-                    {% endifequal %}
-                {% endfor %}
+
+                {% if 'gmap' in child.classes %}
+                    {% load wagtailgmaps_tags %}
+                    {% map_editor child.bound_field.value 100 "%" 300 "px" 8 %}
+                {% endifequal %}
+
             </li>
         {% endfor %}
     </ul>

--- a/wagtailgmaps/templates/wagtailadmin/edit_handlers/multi_field_panel.html
+++ b/wagtailgmaps/templates/wagtailadmin/edit_handlers/multi_field_panel.html
@@ -11,12 +11,12 @@
         {% for child in self.children %}
             <li class="{{ child.classes|join:" " }}">
                 {{ child.render_as_field }}
-
-                {% if 'gmap' in child.classes %}
-                    {% load wagtailgmaps_tags %}
-                    {% map_editor child.bound_field.value 100 "%" 300 "px" 8 %}
-                {% endif %}
-
+                {% for class in child.classes %}
+                   {% if 'gmap' in class %}
+                        {% load wagtailgmaps_tags %}
+                        {% map_editor child.bound_field.value 100 "%" 300 "px" 8 %}
+                    {% endif %}
+                {% endfor %}
             </li>
         {% endfor %}
     </ul>

--- a/wagtailgmaps/templates/wagtailadmin/edit_handlers/multi_field_panel.html
+++ b/wagtailgmaps/templates/wagtailadmin/edit_handlers/multi_field_panel.html
@@ -15,7 +15,7 @@
                 {% if 'gmap' in child.classes %}
                     {% load wagtailgmaps_tags %}
                     {% map_editor child.bound_field.value 100 "%" 300 "px" 8 %}
-                {% endifequal %}
+                {% endif %}
 
             </li>
         {% endfor %}


### PR DESCRIPTION
Fixes:
 - Update templates to work in Wagtail 1.0
 - Update template logic to allow multiple classes on the panel (e.g. `classname="gmap col3"`)

New:
 - Added logic to allow outputting a latlng value rather than the street address. Adding the `gmap--latlng` modifier class to the panel enables the feature.

For example:

```python
    latlng = models.CharField(max_length=255)

    panels = [
        MultiFieldPanel([
            FieldPanel('latlng', classname="gmap gmap--latlng"),
        ], heading="Map location"),
    ]
```
![screen shot 2015-09-10 at 11 55 19](https://cloud.githubusercontent.com/assets/1973559/9786562/de9cbe84-57b2-11e5-8c6c-5438d7d25140.png)
