### PR TITLE
Adds support for Google Maps API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@ Add a couple of necessary constants in your `settings.py` file:
 ...
 WAGTAIL_ADDRESS_MAP_CENTER = 'Wellington, New Zealand'
 WAGTAIL_ADDRESS_MAP_ZOOM = 8
+WAGTAIL_ADDRESS_MAP_KEY = 'xxx'
 ...
 ```
 `WAGTAIL_ADDRESS_MAP_CENTER` must be a properly formatted address. Also, remember valid zoom levels go from 0 to 18. See [Map options](https://developers.google.com/maps/documentation/javascript/tutorial#MapOptions) for details.
+
+As of June 22 2016, Google maps requires an API key. See how to [Get a key](https://developers.google.com/maps/documentation/javascript/get-api-key). While you're there, you'll also need to enable the [Geocoding Service](https://developers.google.com/maps/documentation/javascript/geocoding).
 
 As for now, only fields using `FieldPanel` inside a `MultiFieldPanel` are supported. This is due to the lack of support of the `classname` attribute for other panel fields other than `MultiFieldPanel`.
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='wagtailgmaps',
-    version='0.2.5',
+    version='0.2.6',
     packages=['wagtailgmaps'],
     include_package_data=True,
     license='BSD License',

--- a/wagtailgmaps/templates/wagtailadmin/admin_base.html
+++ b/wagtailgmaps/templates/wagtailadmin/admin_base.html
@@ -1,6 +1,7 @@
 {% overextends "wagtailadmin/admin_base.html" %}
+{% load wagtailgmaps_tags %}
 
 {% block js %}
-    <script src="https://maps.google.com/maps/api/js"></script>
+    {% google_maps_script %}
     {{ block.super }}
 {% endblock %}

--- a/wagtailgmaps/templatetags/wagtailgmaps_tags.py
+++ b/wagtailgmaps/templatetags/wagtailgmaps_tags.py
@@ -29,3 +29,8 @@ def map_editor(address, width, width_units, height, height_units, zoom):
         'height': height,
         'height_units': height_units,
     }
+
+
+@register.simple_tag
+def google_maps_script():
+    return '<script src="https://maps.googleapis.com/maps/api/js?key={}"></script>'.format(settings.WAGTAIL_ADDRESS_MAP_KEY)

--- a/wagtailgmaps/templatetags/wagtailgmaps_tags.py
+++ b/wagtailgmaps/templatetags/wagtailgmaps_tags.py
@@ -2,6 +2,7 @@ import uuid
 
 from django import template
 from django.conf import settings
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
@@ -33,4 +34,4 @@ def map_editor(address, width, width_units, height, height_units, zoom):
 
 @register.simple_tag
 def google_maps_script():
-    return '<script src="https://maps.googleapis.com/maps/api/js?key={}"></script>'.format(settings.WAGTAIL_ADDRESS_MAP_KEY)
+    return mark_safe('<script src="https://maps.googleapis.com/maps/api/js?key={}"></script>'.format(settings.WAGTAIL_ADDRESS_MAP_KEY))

--- a/wagtailgmaps/wagtail_hooks.py
+++ b/wagtailgmaps/wagtail_hooks.py
@@ -26,7 +26,7 @@ def admin_css():
     Add extra CSS files to the admin
     """
     css_files = [
-        'wagtailadmin/css/admin.css',
+        'wagtailgmaps/css/admin.css',
     ]
 
     css_includes = format_html_join(


### PR DESCRIPTION
Fixes #11

API keys are required for new projects: https://developers.google.com/maps/pricing-and-plans/standard-plan-2016-update

Let me know what you think
