### PR TITLE
include language option for google api

### DIFF
--- a/wagtailgmaps/wagtail_hooks.py
+++ b/wagtailgmaps/wagtail_hooks.py
@@ -8,8 +8,12 @@ from wagtail.wagtailcore import hooks
 
 @hooks.register('insert_editor_js')
 def editor_js():
+    maps_js = 'https://maps.googleapis.com/maps/api/js?key={}'.format(settings.WAGTAIL_ADDRESS_MAP_KEY)
+    language = getattr(settings, 'WAGTAIL_ADDRESS_MAP_LANGUAGE')
+    if language:
+        maps_js += '&language={}'.format(language)
     js_files = (
-        'https://maps.googleapis.com/maps/api/js?key={}'.format(settings.WAGTAIL_ADDRESS_MAP_KEY),
+        maps_js,
         static('wagtailgmaps/js/map-field-panel.js'),
     )
     js_includes = format_html_join(

--- a/wagtailgmaps/wagtail_hooks.py
+++ b/wagtailgmaps/wagtail_hooks.py
@@ -9,7 +9,7 @@ from wagtail.wagtailcore import hooks
 @hooks.register('insert_editor_js')
 def editor_js():
     maps_js = 'https://maps.googleapis.com/maps/api/js?key={}'.format(settings.WAGTAIL_ADDRESS_MAP_KEY)
-    language = getattr(settings, 'WAGTAIL_ADDRESS_MAP_LANGUAGE')
+    language = getattr(settings, 'WAGTAIL_ADDRESS_MAP_LANGUAGE', None)
     if language:
         maps_js += '&language={}'.format(language)
     js_files = (


### PR DESCRIPTION
These few lines can utilize the maps API localization feature
example usage (settings.py):
`WAGTAIL_ADDRESS_MAP_LANGUAGE = 'hu'`
https://developers.google.com/maps/documentation/javascript/localization