### PR TITLE
Replace wagtail.admin.edit_handlers

### DIFF
--- a/wagtailgmaps/edit_handlers.py
+++ b/wagtailgmaps/edit_handlers.py
@@ -1,7 +1,7 @@
 import json
 
 from django.conf import settings
-from wagtail.admin.edit_handlers import FieldPanel
+from wagtail.admin.panels import FieldPanel
 
 from .widgets import MapInput
 


### PR DESCRIPTION
`wagtail.admin.edit_handlers` har tagits bort i Wagtail 5+ och döpts om till `wagtail.admin.panels`.